### PR TITLE
data preparation page update and gnps annotations

### DIFF
--- a/pages/1_📁_Data_Preparation.py
+++ b/pages/1_📁_Data_Preparation.py
@@ -36,10 +36,9 @@ else:
             task_id_default = ""
             disabled = False
         task_id = st.text_input("GNPS task ID", task_id_default, disabled=disabled)
-        c1, c2 = st.columns(2)
-        merge_annotations = c1.checkbox("Annotate metabolites", True, help="Merge annotations from GNPS FBMN and analog search if available.")
+        _, c2, _ = st.columns(3)
         if c2.button("Load filed from GNPS", type="primary", disabled=len(task_id) == 0, use_container_width=True):
-            st.session_state["ft_gnps"], st.session_state["md_gnps"] = load_from_gnps(task_id, merge_annotations)
+            st.session_state["ft_gnps"], st.session_state["md_gnps"] = load_from_gnps(task_id)
         
         if "ft_gnps" in st.session_state:
             if not st.session_state["ft_gnps"].empty:

--- a/pages/1_📁_Data_Preparation.py
+++ b/pages/1_📁_Data_Preparation.py
@@ -196,11 +196,10 @@ else:
                             st.warning(f"Can't impute with random values between 1 and lowest value, which is {cutoff_LOD} (rounded).")
 
                 with tabs[2]:
-                    normalization_method = st.selectbox("data normalization method", ["Center-Scaling", 
+                    normalization_method = st.radio("data normalization method", ["None",
+                                                            "Center-Scaling", 
                                                             # "Probabilistic Quotient Normalization (PQN)", 
-                                                            "Total Ion Current (TIC) or sample-centric normalization",
-                                                            "None"])
-
+                                                            "Total Ion Current (TIC) or sample-centric normalization"])
                 with tabs[3]:
                     tab1, tab2 = st.tabs(
                         ["📊 Feature intensity frequency", "📊 Missing values per feature"]

--- a/pages/7_One-way_ANOVA_&_Tukey's.py
+++ b/pages/7_One-way_ANOVA_&_Tukey's.py
@@ -29,7 +29,7 @@ if not st.session_state.data.empty:
             st.session_state.anova_attribute,
             corrections_map[st.session_state.p_value_correction]
         )
-        st.experimental_rerun()
+        st.rerun()
 
     if not st.session_state.df_anova.empty:
         attribute_options = list(
@@ -58,7 +58,7 @@ if not st.session_state.data.empty:
                 st.session_state.tukey_elements,
                 corrections_map[st.session_state.p_value_correction]
             )
-            st.experimental_rerun()
+            st.rerun()
 
     tab_options = [
         "📈 ANOVA: plot",

--- a/pages/8_Kruskal-Wallis_&_Dunn's.py
+++ b/pages/8_Kruskal-Wallis_&_Dunn's.py
@@ -28,7 +28,7 @@ if not st.session_state.data.empty:
             st.session_state.data, st.session_state.kruskal_attribute,
             corrections_map[st.session_state.p_value_correction]
         )
-        st.experimental_rerun()
+        st.rerun()
 
     if not st.session_state.df_kruskal.empty:
         if any(st.session_state.df_kruskal["significant"]):
@@ -58,7 +58,7 @@ if not st.session_state.data.empty:
                     st.session_state.dunn_elements,
                     corrections_map[st.session_state.p_value_correction]
                 )
-                st.experimental_rerun()
+                st.rerun()
         else:
             st.warning("No significant metabolites found in Kruskal Wallis test after p-value correction.")
 

--- a/pages/9_Student's_t-test.py
+++ b/pages/9_Student's_t-test.py
@@ -53,7 +53,7 @@ if not st.session_state.data.empty:
             st.session_state.ttest_correction,
             corrections_map[st.session_state.p_value_correction]
         )
-        st.experimental_rerun()
+        st.rerun()
 
     if not st.session_state.df_ttest.empty:
         tabs = st.tabs(

--- a/src/common.py
+++ b/src/common.py
@@ -14,7 +14,8 @@ dataframe_names = ("md",
                    "df_important_features",
                    "df_oob",
                    "ft_gnps",
-                   "md_gnps")
+                   "md_gnps",
+                   "df_gnps_annotations")
 
 corrections_map = {"Bonferroni": "bonf",
                    "Sidak": "sidak",


### PR DESCRIPTION
Now, annotations from GNPS are always fetched. However, the feature table indeces are not replaced by annotations, since that lead to some issues. Now they are stored in a df in session state "df_gnps_annotations" and can be accessed from anywhere. If we plan to add more annotations for instance from SIRIUS, we can do the same.